### PR TITLE
Support bullmq queue prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,11 @@ createBullBoard({
 3. `description` (default: `empty`)
    Queue description text.
 
-4. `prefix` (default: `empty`)
-   Job name prefix.
+4. `prefix` (default: queue `opts.prefix`)
+   Job name prefix. When not provided, the adapter will reuse the queue's own
+   prefix so that queues created with a custom Redis namespace are displayed
+   correctly. BullMQ uses the prefix `bull` by default, but you can override it
+   through `opts.prefix` and the dashboard will reflect it automatically.
 5. `queueAdapter.setFormatter(field: 'data' | 'returnValue' | 'name', formatter: (fieldData) => any)`
    You can specify a formatter for `'data' | 'returnValue' | 'name'` job's fields.
 

--- a/README.md
+++ b/README.md
@@ -212,10 +212,11 @@ createBullBoard({
 4. `prefix` (default: `''`)
    Job name prefix shown on the dashboard. If omitted, the adapter will
    automatically detect a custom queue namespace by inspecting the queue
-   instance. When `opts.prefix` differs from BullMQ's default (`bull`), the
-   dashboard will prepend it followed by `:` so that queues using a custom
-   Redis prefix appear correctly without affecting queues using the default
-   namespace.
+   instance. The prefix is read from either `queue.opts.prefix` or
+   `queue.opts.connection.prefix` when present. When the resolved prefix differs
+   from BullMQ's default (`bull`), the dashboard will prepend it followed by `:`
+   so that queues using a custom Redis namespace appear correctly without
+   affecting queues using the default namespace.
 5. `queueAdapter.setFormatter(field: 'data' | 'returnValue' | 'name', formatter: (fieldData) => any)`
    You can specify a formatter for `'data' | 'returnValue' | 'name'` job's fields.
 

--- a/README.md
+++ b/README.md
@@ -209,11 +209,13 @@ createBullBoard({
 3. `description` (default: `empty`)
    Queue description text.
 
-4. `prefix` (default: queue `opts.prefix`)
-   Job name prefix. When not provided, the adapter will reuse the queue's own
-   prefix so that queues created with a custom Redis namespace are displayed
-   correctly. BullMQ uses the prefix `bull` by default, but you can override it
-   through `opts.prefix` and the dashboard will reflect it automatically.
+4. `prefix` (default: `''`)
+   Job name prefix shown on the dashboard. If omitted, the adapter will
+   automatically detect a custom queue namespace by inspecting the queue
+   instance. When `opts.prefix` differs from BullMQ's default (`bull`), the
+   dashboard will prepend it followed by `:` so that queues using a custom
+   Redis prefix appear correctly without affecting queues using the default
+   namespace.
 5. `queueAdapter.setFormatter(field: 'data' | 'returnValue' | 'name', formatter: (fieldData) => any)`
    You can specify a formatter for `'data' | 'returnValue' | 'name'` job's fields.
 

--- a/packages/api/src/queueAdapters/bull.ts
+++ b/packages/api/src/queueAdapters/bull.ts
@@ -13,7 +13,12 @@ import { BaseAdapter } from './base';
 
 export class BullAdapter extends BaseAdapter {
   constructor(public queue: Queue, options: Partial<QueueAdapterOptions> = {}) {
-    super('bull', { ...options, allowCompletedRetries: false });
+    const queuePrefix = (queue as any)?.opts?.prefix ?? '';
+    super('bull', {
+      ...options,
+      prefix: options.prefix ?? queuePrefix,
+      allowCompletedRetries: false,
+    });
 
     if (!(queue instanceof BullQueue)) {
       throw new Error(`You've used the Bull adapter with a non-Bull queue.`);

--- a/packages/api/src/queueAdapters/bull.ts
+++ b/packages/api/src/queueAdapters/bull.ts
@@ -13,10 +13,13 @@ import { BaseAdapter } from './base';
 
 export class BullAdapter extends BaseAdapter {
   constructor(public queue: Queue, options: Partial<QueueAdapterOptions> = {}) {
-    const queuePrefix = (queue as any)?.opts?.prefix ?? '';
+    const queuePrefix =
+      (queue as any)?.opts?.prefix ?? (queue as any)?.opts?.redis?.keyPrefix ?? '';
+    const isCustom = queuePrefix && queuePrefix !== 'bull';
     super('bull', {
       ...options,
-      prefix: options.prefix ?? queuePrefix,
+      prefix: options.prefix ?? (isCustom ? `${queuePrefix}:` : ''),
+      delimiter: options.delimiter ?? (isCustom ? ':' : ''),
       allowCompletedRetries: false,
     });
 

--- a/packages/api/src/queueAdapters/bull.ts
+++ b/packages/api/src/queueAdapters/bull.ts
@@ -14,7 +14,10 @@ import { BaseAdapter } from './base';
 export class BullAdapter extends BaseAdapter {
   constructor(public queue: Queue, options: Partial<QueueAdapterOptions> = {}) {
     const queuePrefix =
-      (queue as any)?.opts?.prefix ?? (queue as any)?.opts?.redis?.keyPrefix ?? '';
+      (queue as any)?.opts?.prefix ??
+      (queue as any)?.opts?.connection?.prefix ??
+      (queue as any)?.opts?.redis?.keyPrefix ??
+      '';
     const isCustom = queuePrefix && queuePrefix !== 'bull';
     super('bull', {
       ...options,

--- a/packages/api/src/queueAdapters/bullMQ.ts
+++ b/packages/api/src/queueAdapters/bullMQ.ts
@@ -13,7 +13,11 @@ import { BaseAdapter } from './base';
 export class BullMQAdapter extends BaseAdapter {
   constructor(private queue: Queue, options: Partial<QueueAdapterOptions> = {}) {
     const libName = 'bullmq';
-    super(libName, options);
+    const queuePrefix = (queue as any)?.opts?.prefix ?? '';
+    super(libName, {
+      ...options,
+      prefix: options.prefix ?? queuePrefix,
+    });
     if (
       !(queue instanceof Queue || `${(queue as Queue).metaValues?.version}`?.startsWith(libName))
     ) {

--- a/packages/api/src/queueAdapters/bullMQ.ts
+++ b/packages/api/src/queueAdapters/bullMQ.ts
@@ -13,7 +13,10 @@ import { BaseAdapter } from './base';
 export class BullMQAdapter extends BaseAdapter {
   constructor(private queue: Queue, options: Partial<QueueAdapterOptions> = {}) {
     const libName = 'bullmq';
-    const queuePrefix = (queue as any)?.opts?.prefix ?? '';
+    const queuePrefix =
+      (queue as any)?.opts?.prefix ??
+      (queue as any)?.opts?.connection?.prefix ??
+      '';
     const isCustom = queuePrefix && queuePrefix !== 'bull';
     super(libName, {
       ...options,

--- a/packages/api/src/queueAdapters/bullMQ.ts
+++ b/packages/api/src/queueAdapters/bullMQ.ts
@@ -14,9 +14,11 @@ export class BullMQAdapter extends BaseAdapter {
   constructor(private queue: Queue, options: Partial<QueueAdapterOptions> = {}) {
     const libName = 'bullmq';
     const queuePrefix = (queue as any)?.opts?.prefix ?? '';
+    const isCustom = queuePrefix && queuePrefix !== 'bull';
     super(libName, {
       ...options,
-      prefix: options.prefix ?? queuePrefix,
+      prefix: options.prefix ?? (isCustom ? `${queuePrefix}:` : ''),
+      delimiter: options.delimiter ?? (isCustom ? ':' : ''),
     });
     if (
       !(queue instanceof Queue || `${(queue as Queue).metaValues?.version}`?.startsWith(libName))

--- a/packages/api/tests/api/index.spec.ts
+++ b/packages/api/tests/api/index.spec.ts
@@ -251,7 +251,27 @@ describe('happy', () => {
         .then((res) => {
           const responseJson = JSON.parse(res.text);
 
-          expect(responseJson).toHaveProperty('version', expect.stringMatching(/\d+\.\d+\.\d+/));
+        expect(responseJson).toHaveProperty('version', expect.stringMatching(/\d+\.\d+\.\d+/));
+      });
+    });
+
+    it('should include custom prefix in queue name', async () => {
+      const prefixed = new Queue('Paint', { connection, prefix: 'custom' });
+      queueList.push(prefixed);
+
+      createBullBoard({
+        queues: [new BullMQAdapter(prefixed)],
+        serverAdapter,
+      });
+
+      await request(serverAdapter.getRouter())
+        .get('/api/queues')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .then((res) => {
+          const queues = JSON.parse(res.text).queues;
+          expect(queues).toHaveLength(1);
+          expect(queues[0].name).toBe('custom:Paint');
         });
     });
   });

--- a/packages/api/tests/api/index.spec.ts
+++ b/packages/api/tests/api/index.spec.ts
@@ -274,5 +274,26 @@ describe('happy', () => {
           expect(queues[0].name).toBe('custom:Paint');
         });
     });
+
+    it('should read prefix from connection options', async () => {
+      const connPrefix = { ...connection, prefix: 'conn' } as any;
+      const prefixed = new Queue('Paint', { connection: connPrefix });
+      queueList.push(prefixed);
+
+      createBullBoard({
+        queues: [new BullMQAdapter(prefixed)],
+        serverAdapter,
+      });
+
+      await request(serverAdapter.getRouter())
+        .get('/api/queues')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .then((res) => {
+          const queues = JSON.parse(res.text).queues;
+          expect(queues).toHaveLength(1);
+          expect(queues[0].name).toBe('conn:Paint');
+        });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- infer queue adapter prefix from the queue's `opts.prefix`
- clarify prefix usage in docs

## Testing
- `yarn lint`
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:6379)*

------
https://chatgpt.com/codex/tasks/task_e_687083522fa883329cca9b8ee2e3d3d9